### PR TITLE
Generating Message Sent To Customer Upon Order and Repayments

### DIFF
--- a/app/Channels/SmsChannel.php
+++ b/app/Channels/SmsChannel.php
@@ -34,6 +34,7 @@ class SmsChannel
     {
         $message = $notification->toSms($notifiable);
         // Send notification to the $notifiable instance...
+        dd( $message);
         $resp = $this->messageService->sendMessage($this->appendPrefix($notifiable->phone), $message);
         if ($resp->messages[0]->status->groupId == 5) throw new AException($resp->messages[0]->status->description, 422);
     }

--- a/app/Channels/SmsChannel.php
+++ b/app/Channels/SmsChannel.php
@@ -34,7 +34,7 @@ class SmsChannel
     {
         $message = $notification->toSms($notifiable);
         // Send notification to the $notifiable instance...
-        dd( $message);
+        // dd( $message);
         $resp = $this->messageService->sendMessage($this->appendPrefix($notifiable->phone), $message);
         if ($resp->messages[0]->status->groupId == 5) throw new AException($resp->messages[0]->status->description, 422);
     }

--- a/app/Channels/SmsChannel.php
+++ b/app/Channels/SmsChannel.php
@@ -40,12 +40,13 @@ class SmsChannel
     }
 
 
-    private function appendPrefix(string $number){
+    private function appendPrefix(string $number)
+    {
         if (!$number) return '';
         $pre = '234';
-        if($number[0] == 0) {
+        if ($number[0] == 0) {
             return $pre . substr($number, 1);
-        }elseif (substr($number, 0, 3) == $pre){
+        } elseif (substr($number, 0, 3) == $pre) {
             return $number;
         }
         return $pre . $number;

--- a/app/Channels/SmsChannel.php
+++ b/app/Channels/SmsChannel.php
@@ -34,7 +34,6 @@ class SmsChannel
     {
         $message = $notification->toSms($notifiable);
         // Send notification to the $notifiable instance...
-        // dd( $message);
         $resp = $this->messageService->sendMessage($this->appendPrefix($notifiable->phone), $message);
         if ($resp->messages[0]->status->groupId == 5) throw new AException($resp->messages[0]->status->description, 422);
     }

--- a/app/Events/NewOrderEvent.php
+++ b/app/Events/NewOrderEvent.php
@@ -2,6 +2,7 @@
 
 namespace App\Events;
 
+use App\NewOrder;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;
@@ -20,7 +21,7 @@ class NewOrderEvent
      *
      * @param $order
      */
-    public function __construct($order)
+    public function __construct(NewOrder $order)
     {
         $this->order = $order;
     }

--- a/app/Helper/Constants.php
+++ b/app/Helper/Constants.php
@@ -39,7 +39,11 @@ class Constants
     Visit the showroom or call us when you transfer to confirm payment. 
     Do not ever pay money into any altara agents account and always demand your receipt.';
     // const SUCCESSFUL_ORDER = 'Dear customer_name, this is to notify you that your order order_number was successful';
-    const SUCCESSFUL_REPAYMENT = 'Dear customer_name, this is to notify you that your repayment towards order order_number was successful';
+    const SUCCESSFUL_REPAYMENT = 'Hello [customer_name], thank you we have received your repayment. 
+    You have made [no_of_repayment_made]/[total_no_of_repayment_expected] repayment
+    Total paid so far = [total_of_repayment_made]. 
+    Total debit remaining = [total_of_repayment_not_made]
+    ';
 
 
     static $reminderMessages = [

--- a/app/Helper/Constants.php
+++ b/app/Helper/Constants.php
@@ -4,6 +4,7 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
+
 namespace App\Helper;
 
 /**
@@ -12,7 +13,8 @@ namespace App\Helper;
  *
  * @author: Adeniyi
  */
-class Constants {
+class Constants
+{
 
     const F_SMS = 'first_sms';
     const S_SMS = 'second_sms';
@@ -30,7 +32,13 @@ class Constants {
     const ORDER_NOTIFICATION_ERROR = 'An Error Occured while trying to send Order notification to customer customer_name with Order order_number';
     const RENEWAL_NOTIFICATION_ERROR = 'An Error Occured while trying to send renewal notification to customer customer_name with Order order_number';
 
-    const SUCCESSFUL_ORDER = 'Dear customer_name, this is to notify you that your order order_number was successful';
+    const SUCCESSFUL_ORDER = 'Hello [customer_name],
+    thank you for patronizing us and hope you enjoy using your [product_name] for business or leisure. 
+    You have paid [down_payment] and still owe [total_debt_left]. 
+    Your next repayment of repayment is due on [next_payment_date]. 
+    Visit the showroom or call us when you transfer to confirm payment. 
+    Do not ever pay money into any altara agents account and always demand your receipt.';
+    // const SUCCESSFUL_ORDER = 'Dear customer_name, this is to notify you that your order order_number was successful';
     const SUCCESSFUL_REPAYMENT = 'Dear customer_name, this is to notify you that your repayment towards order order_number was successful';
 
 

--- a/app/Helper/Constants.php
+++ b/app/Helper/Constants.php
@@ -33,8 +33,8 @@ class Constants
     const RENEWAL_NOTIFICATION_ERROR = 'An Error Occured while trying to send renewal notification to customer customer_name with Order order_number';
 
     const SUCCESSFUL_ORDER = 'Hello [customer_name],
-    thank you for patronizing us and hope you enjoy using your [product_name] for business or leisure. 
-    You have paid [down_payment] and still owe [total_debt_left]. 
+    Thank you for patronizing us and hope you enjoy using your [product_name] for business or leisure. 
+    You have paid [down_payment] and still owe [repayment]. 
     Your next repayment of repayment is due on [next_payment_date]. 
     Visit the showroom or call us when you transfer to confirm payment. 
     Do not ever pay money into any altara agents account and always demand your receipt.';

--- a/app/Helper/Helper.php
+++ b/app/Helper/Helper.php
@@ -55,15 +55,28 @@ class Helper
         //loop through length
         for ($i = 0; $i < $length; ++$i) {
             //add to pieces
-            $pieces [] = $keyspace[random_int(0, $max)];
+            $pieces[] = $keyspace[random_int(0, $max)];
         }
         //return generated sku
         return implode('', $pieces);
-
     }
 
     public static function generatePrefix(string $target, int $stop = 3, int $start = 0)
     {
         return Str::upper(Str::substr($target, $start, $stop));
+    }
+
+    /**
+     * Get the array regex representation of the keys.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    public static function generateReplacementKeys(array $keys)
+    {
+        //construct a new array to construct regex to search for when replacing
+        return array_map(function ($value) {
+            return '/\[' . $value . '\]/';
+        }, $keys);
     }
 }

--- a/app/Http/Controllers/RepaymentController.php
+++ b/app/Http/Controllers/RepaymentController.php
@@ -63,7 +63,10 @@ class RepaymentController extends Controller
         $order = Order::findOrFail($request->order_id);
         $order->amount = $request->amount;
         $order->payment_type_id = $paymentType;
-        event(new OldRepaymentEvent($order));
+        if (env('SEND_REORDER_SMS')) {
+             event(new OldRepaymentEvent($order));
+        }
+       
 
         return response()->json([
             'saved' => true,

--- a/app/Http/Controllers/RepaymentController.php
+++ b/app/Http/Controllers/RepaymentController.php
@@ -47,7 +47,7 @@ class RepaymentController extends Controller
         ]);
         $amortization = null;
 
-        switch ($request->type){
+        switch ($request->type) {
             case 'formal':
                 $amortization = RepaymentFormal::where('repayment_id', $request->repayment_id)->first();
                 break;
@@ -63,10 +63,9 @@ class RepaymentController extends Controller
         $order = Order::findOrFail($request->order_id);
         $order->amount = $request->amount;
         $order->payment_type_id = $paymentType;
-        if (env('SEND_REORDER_SMS')) {
-             event(new OldRepaymentEvent($order));
-        }
-       
+        event(new OldRepaymentEvent($order));
+
+
 
         return response()->json([
             'saved' => true,

--- a/app/Listeners/NewOrderListener.php
+++ b/app/Listeners/NewOrderListener.php
@@ -24,7 +24,7 @@ class NewOrderListener
             $p = app()->make('App\Amortization\\' . Str::studly($event->order->repaymentCycle->name), ['order' => $event->order])->create();
             try {
                 if (env('SEND_ORDER_SMS')) {
-                    $event->order->customer->notify(new NewOrderNotification($event->order->fresh()));
+                    $event->order->customer->notify(new NewOrderNotification($event->order));
                 }
             } catch (\Exception $e) {
                 //Implement a Logger service to log this error

--- a/app/Listeners/NewOrderListener.php
+++ b/app/Listeners/NewOrderListener.php
@@ -21,10 +21,12 @@ class NewOrderListener
     public function handle(NewOrderEvent $event)
     {
         try {
-            $p = app()->make('App\Amortization\\' .Str::studly($event->order->repaymentCycle->name), ['order' => $event->order])->create();
+            $p = app()->make('App\Amortization\\' . Str::studly($event->order->repaymentCycle->name), ['order' => $event->order])->create();
             try {
-                $event->order->customer->notify(new NewOrderNotification($event->order));
-            }catch (\Exception $e){
+                if (env('SEND_ORDER_SMS')) {
+                    $event->order->customer->notify(new NewOrderNotification($event->order->fresh()));
+                }
+            } catch (\Exception $e) {
                 //Implement a Logger service to log this error
                 LogHelper::error(strtr(Constants::ORDER_NOTIFICATION_ERROR, $event->order->toArray()), $e);
             }

--- a/app/Listeners/RepaymentListener.php
+++ b/app/Listeners/RepaymentListener.php
@@ -21,8 +21,10 @@ class RepaymentListener
     {
         $customer = Customer::find($event->newOrder['customer_id']);
         try {
-            $customer->notify(new RepaymentNotification($event->newOrder));
-        }catch (\Exception $e) {
+            if (env('SEND_REORDER_SMS')) {
+                $customer->notify(new RepaymentNotification($event->newOrder));
+            }
+        } catch (\Exception $e) {
             LogHelper::error(strtr(Constants::REPAYMENT_NOTIFICATION_ERROR, $event->newOrder->toArray()), $e);
         }
     }

--- a/app/NewOrder.php
+++ b/app/NewOrder.php
@@ -201,10 +201,6 @@ class NewOrder extends Model
             "order_date" => $this->order_date,
             "owner" => $this->owner->full_name ?? '',
             "sales_type" => $this->salesCategory ?? '',
-            
-            // "total_debt_left" => number_format(($this->product_price - $this->down_payment), 2),
-            // "repayment_amount" => number_format($this->repayment, 2),
-            // "next_payment_date" =>  $this->amortization[0]->expected_payment_date,
         ];
     }
 }

--- a/app/NewOrder.php
+++ b/app/NewOrder.php
@@ -40,7 +40,7 @@ class NewOrder extends Model
             'discount' => 'sometimes|array',
             'discount.*' => 'sometimes|numeric|exists:discounts,id',
             'product_price' => ['required', new Money],
-            'custom_date' => 'integer|min:1|max:31|required_if:repayment_cycle_id,'. $id
+            'custom_date' => 'integer|min:1|max:31|required_if:repayment_cycle_id,' . $id
         ];
     }
 
@@ -59,7 +59,7 @@ class NewOrder extends Model
             'status_id' => 'sometimes|required|exists:order_statuses,id',
             'repayment' => ['sometimes', 'required', new Money],
             'down_payment' => ['sometimes', 'required', new Money],
-            'product_price' => ['sometimes','required', new Money],
+            'product_price' => ['sometimes', 'required', new Money],
             'order_date' => 'sometimes|required|date',
         ];
     }
@@ -69,7 +69,8 @@ class NewOrder extends Model
         return RepaymentCycle::where('name', RepaymentCycle::CUSTOM)->first()->id;
     }
 
-    public function businessType(){
+    public function businessType()
+    {
         return $this->belongsTo(BusinessType::class);
     }
     public function owner()
@@ -77,56 +78,68 @@ class NewOrder extends Model
         return $this->belongsTo(User::class, 'owner_id');
     }
 
-    public function paymentMethod(){
+    public function paymentMethod()
+    {
         return $this->hasOne(PaymentMethod::class);
     }
 
-    public function repaymentDuration (){
+    public function repaymentDuration()
+    {
         return $this->belongsTo(RepaymentDuration::class);
     }
 
-    public function repaymentCycle(){
+    public function repaymentCycle()
+    {
         return $this->belongsTo(RepaymentCycle::class);
     }
 
-    public function amortization(){
+    public function amortization()
+    {
         return $this->hasMany(Amortization::class);
     }
 
-    public function orderStatus(){
+    public function orderStatus()
+    {
         return $this->belongsTo(OrderStatus::class, 'status_id');
     }
     public function salesCategory()
     {
         return $this->belongsTo(SalesCategory::class, 'sales_category_id');
     }
-    public function customer(){
+    public function customer()
+    {
         return $this->belongsTo(Customer::class, 'customer_id');
     }
-    public function user(){
+    public function user()
+    {
         return $this->belongsTo(User::class);
     }
 
-    public function branch(){
+    public function branch()
+    {
         return $this->belongsTo(Branch::class);
     }
 
-    public function product(){
+    public function product()
+    {
         return $this->belongsTo(Product::class);
     }
 
-    public function customDate(){
+    public function customDate()
+    {
         return $this->hasOne(CustomRepaymentDate::class);
     }
 
-    public function authCode(){
+    public function authCode()
+    {
         return $this->hasOne(PaystackAuthCode::class, 'order_id', 'order_number');
     }
 
-    public function defaulter(){
-        $onTime = $this->amortization()->where('actual_amount','>',1)->count();
+    public function defaulter()
+    {
+        $onTime = $this->amortization()->where('actual_amount', '>', 1)->count();
         $total = $this->amortization()->count();
-        return ($onTime /$total) * 100;
+        return ($onTime / $total) * 100;
     }
 
     public function discounts()
@@ -152,7 +165,7 @@ class NewOrder extends Model
      */
     public function getOrderPaymentMethodAttribute()
     {
-        return $this->payments()->whereIn('payment_type_id', function ($query){
+        return $this->payments()->whereIn('payment_type_id', function ($query) {
             $query->select('id')->from('payment_types')->where('type', PaymentType::DOWNPAYMENT);
         })->first()->paymentMethod->name ?? null;
     }
@@ -187,8 +200,11 @@ class NewOrder extends Model
             "customer" => $this->customer,
             "order_date" => $this->order_date,
             "owner" => $this->owner->full_name ?? '',
-            "sales_type" => $this->salesCategory ?? ''
+            "sales_type" => $this->salesCategory ?? '',
+            
+            "total_debt_left" => number_format(($this->product_price - $this->down_payment), 2),
+            "repayment_amount" => number_format($this->repayment, 2),
+            "next_payment_date" =>  $this->amortization[0]->expected_payment_date,
         ];
     }
 }
-

--- a/app/NewOrder.php
+++ b/app/NewOrder.php
@@ -202,9 +202,9 @@ class NewOrder extends Model
             "owner" => $this->owner->full_name ?? '',
             "sales_type" => $this->salesCategory ?? '',
             
-            "total_debt_left" => number_format(($this->product_price - $this->down_payment), 2),
-            "repayment_amount" => number_format($this->repayment, 2),
-            "next_payment_date" =>  $this->amortization[0]->expected_payment_date,
+            // "total_debt_left" => number_format(($this->product_price - $this->down_payment), 2),
+            // "repayment_amount" => number_format($this->repayment, 2),
+            // "next_payment_date" =>  $this->amortization[0]->expected_payment_date,
         ];
     }
 }

--- a/app/Notifications/NewOrderNotification.php
+++ b/app/Notifications/NewOrderNotification.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use App\Mail\NewOrder as Mailable;
+use App\Helper\Helper;
 
 class NewOrderNotification extends Notification
 {
@@ -65,7 +66,7 @@ class NewOrderNotification extends Notification
      */
     public function toSms($notifiable)
     {
-        $replacementKeys = $this->generateReplacementKeys(array_keys($this->data));
+        $replacementKeys = Helper::generateReplacementKeys(array_keys($this->data));
         $replacementValues    = array_values($this->data);
         $message = preg_replace($replacementKeys, $replacementValues, Constants::SUCCESSFUL_ORDER);
         return $message;
@@ -80,19 +81,5 @@ class NewOrderNotification extends Notification
     public function toArray($notifiable)
     {
         return $this->data;
-    }
-
-    /**
-     * Get the array regex representation of the keys.
-     *
-     * @param  array  $keys
-     * @return array
-     */
-    public function generateReplacementKeys(array $keys)
-    {
-        //construct a new array to construct regex to search for when replacing
-        return array_map(function ($value) {
-            return '/\[' . $value . '\]/';
-        }, $keys);
     }
 }

--- a/app/Notifications/NewOrderNotification.php
+++ b/app/Notifications/NewOrderNotification.php
@@ -27,7 +27,9 @@ class NewOrderNotification extends Notification
      */
     public function __construct(NewOrder $data)
     {
+      
         $this->data = $data->toArray();
+        $this->data["next_payment_date"] = $data->amortization[0]->expected_payment_date;
     }
 
     /**
@@ -69,6 +71,7 @@ class NewOrderNotification extends Notification
         $myNewArray =  array_map(function ($value) {
             return '/\[' . $value . '\]/';
         }, $find);
+        // dd($replace);
         $new_string = preg_replace($myNewArray, $replace, Constants::SUCCESSFUL_ORDER);
         return $new_string;
         // return strtr(Constants::SUCCESSFUL_ORDER, $this->data);

--- a/app/Notifications/NewOrderNotification.php
+++ b/app/Notifications/NewOrderNotification.php
@@ -62,7 +62,16 @@ class NewOrderNotification extends Notification
      */
     public function toSms($notifiable)
     {
-        return strtr(Constants::SUCCESSFUL_ORDER, $this->data);
+        //get all array_keys and values of the this->data to be replaced
+        $find       = array_keys($this->data);
+        $replace    = array_values($this->data);
+        //construct a new array to construct regex to search for when replacing
+        $myNewArray =  array_map(function ($value) {
+            return '/\[' . $value . '\]/';
+        }, $find);
+        $new_string = preg_replace($myNewArray, $replace, Constants::SUCCESSFUL_ORDER);
+        return $new_string;
+        // return strtr(Constants::SUCCESSFUL_ORDER, $this->data);
     }
 
     /**

--- a/app/Notifications/NewOrderNotification.php
+++ b/app/Notifications/NewOrderNotification.php
@@ -27,8 +27,9 @@ class NewOrderNotification extends Notification
      */
     public function __construct(NewOrder $data)
     {
-      
+
         $this->data = $data->toArray();
+        //Attaching required parameters from amortization to data to send sms to customer
         $this->data["next_payment_date"] = $data->amortization[0]->expected_payment_date;
     }
 
@@ -64,17 +65,10 @@ class NewOrderNotification extends Notification
      */
     public function toSms($notifiable)
     {
-        //get all array_keys and values of the this->data to be replaced
-        $find       = array_keys($this->data);
-        $replace    = array_values($this->data);
-        //construct a new array to construct regex to search for when replacing
-        $myNewArray =  array_map(function ($value) {
-            return '/\[' . $value . '\]/';
-        }, $find);
-        // dd($replace);
-        $new_string = preg_replace($myNewArray, $replace, Constants::SUCCESSFUL_ORDER);
-        return $new_string;
-        // return strtr(Constants::SUCCESSFUL_ORDER, $this->data);
+        $replacementKeys = $this->generateReplacementKeys(array_keys($this->data));
+        $replacementValues    = array_values($this->data);
+        $message = preg_replace($replacementKeys, $replacementValues, Constants::SUCCESSFUL_ORDER);
+        return $message;
     }
 
     /**
@@ -86,5 +80,19 @@ class NewOrderNotification extends Notification
     public function toArray($notifiable)
     {
         return $this->data;
+    }
+
+    /**
+     * Get the array regex representation of the keys.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    public function generateReplacementKeys(array $keys)
+    {
+        //construct a new array to construct regex to search for when replacing
+        return array_map(function ($value) {
+            return '/\[' . $value . '\]/';
+        }, $keys);
     }
 }

--- a/app/Notifications/RepaymentNotification.php
+++ b/app/Notifications/RepaymentNotification.php
@@ -75,7 +75,6 @@ class RepaymentNotification extends Notification
         $replacementValues    = array_values($this->data);
         $message = preg_replace($replacementKeys, $replacementValues, Constants::SUCCESSFUL_REPAYMENT);
         return $message;
-        // return strtr(Constants::SUCCESSFUL_REPAYMENT, $this->data);
     }
 
     /**

--- a/app/Notifications/RepaymentNotification.php
+++ b/app/Notifications/RepaymentNotification.php
@@ -30,6 +30,12 @@ class RepaymentNotification extends Notification
     {
         $this->amortization = $data->amortization();
         $this->data = $data->toArray();
+        //Attaching required parameters from amortization to data to send sms to customer
+        $this->data['total_no_of_repayment_expected'] = $data->amortization->count();
+        $totalOfRepaymentMade = $data->amortization->where('actual_payment_date', '!=', null)->sum('actual_amount');
+        $this->data['total_of_repayment_made'] =  $totalOfRepaymentMade;
+        $this->data['total_of_repayment_not_made'] = abs($totalOfRepaymentMade - $data->amortization->sum('expected_amount'));
+        $this->data['no_of_repayment_made'] = $data->amortization->where('actual_payment_date', '!=', null)->count();
     }
 
     /**
@@ -64,7 +70,11 @@ class RepaymentNotification extends Notification
      */
     public function toSms($notifiable)
     {
-        return strtr(Constants::SUCCESSFUL_REPAYMENT, $this->data);
+        $replacementKeys = $this->generateReplacementKeys(array_keys($this->data));
+        $replacementValues    = array_values($this->data);
+        $message = preg_replace($replacementKeys, $replacementValues, Constants::SUCCESSFUL_REPAYMENT);
+        return $message;
+        // return strtr(Constants::SUCCESSFUL_REPAYMENT, $this->data);
     }
 
     /**
@@ -76,5 +86,18 @@ class RepaymentNotification extends Notification
     public function toArray($notifiable)
     {
         return $this->data;
+    }
+     /**
+     * Get the array regex representation of the keys.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    public function generateReplacementKeys(array $keys)
+    {
+        //construct a new array to construct regex to search for when replacing
+        return array_map(function ($value) {
+            return '/\[' . $value . '\]/';
+        }, $keys);
     }
 }

--- a/app/Notifications/RepaymentNotification.php
+++ b/app/Notifications/RepaymentNotification.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Channels\SmsChannel;
 use App\Helper\Constants;
+use App\Helper\Helper;
 use App\NewOrder;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -70,7 +71,7 @@ class RepaymentNotification extends Notification
      */
     public function toSms($notifiable)
     {
-        $replacementKeys = $this->generateReplacementKeys(array_keys($this->data));
+        $replacementKeys = Helper::generateReplacementKeys(array_keys($this->data));
         $replacementValues    = array_values($this->data);
         $message = preg_replace($replacementKeys, $replacementValues, Constants::SUCCESSFUL_REPAYMENT);
         return $message;
@@ -86,18 +87,5 @@ class RepaymentNotification extends Notification
     public function toArray($notifiable)
     {
         return $this->data;
-    }
-     /**
-     * Get the array regex representation of the keys.
-     *
-     * @param  array  $keys
-     * @return array
-     */
-    public function generateReplacementKeys(array $keys)
-    {
-        //construct a new array to construct regex to search for when replacing
-        return array_map(function ($value) {
-            return '/\[' . $value . '\]/';
-        }, $keys);
     }
 }

--- a/app/Repositories/NewOrderRepository.php
+++ b/app/Repositories/NewOrderRepository.php
@@ -44,7 +44,7 @@ class NewOrderRepository extends Repository
             'status_id' => OrderStatus::where('name', OrderStatus::ACTIVE)->first()->id,
             'product_id' => $inventory->product_id
         ]));
-        if (RepaymentCycle::find($data['repayment_cycle_id'])->name === RepaymentCycle::CUSTOM) {
+        if (RepaymentCycle::find($data['repayment_cycle_id'])->name === RepaymentCycle::CUSTOM){
             $order->customDate()->create(['custom_date' => $data['custom_date']]);
             $order->custom_date = $data['custom_date'];
         }
@@ -59,9 +59,7 @@ class NewOrderRepository extends Repository
         $order->payment_method_id = $data['payment_method_id'];
         $order->bank_id = $data['bank_id'];
         $order->inventory = $inventory;
-        if (env('SEND_ORDER_SMS')) {
-            event(new NewOrderEvent($order));
-        }
+        event(new NewOrderEvent($order));
 
         return $order->fresh();
     }
@@ -78,5 +76,6 @@ class NewOrderRepository extends Repository
         } catch (Exception $e) {
             throw new AException($e->getMessage(), $e->getCode());
         }
+
     }
 }

--- a/app/Repositories/NewOrderRepository.php
+++ b/app/Repositories/NewOrderRepository.php
@@ -44,7 +44,7 @@ class NewOrderRepository extends Repository
             'status_id' => OrderStatus::where('name', OrderStatus::ACTIVE)->first()->id,
             'product_id' => $inventory->product_id
         ]));
-        if (RepaymentCycle::find($data['repayment_cycle_id'])->name === RepaymentCycle::CUSTOM){
+        if (RepaymentCycle::find($data['repayment_cycle_id'])->name === RepaymentCycle::CUSTOM) {
             $order->customDate()->create(['custom_date' => $data['custom_date']]);
             $order->custom_date = $data['custom_date'];
         }
@@ -59,7 +59,9 @@ class NewOrderRepository extends Repository
         $order->payment_method_id = $data['payment_method_id'];
         $order->bank_id = $data['bank_id'];
         $order->inventory = $inventory;
-        event(new NewOrderEvent($order));
+        if (env('SEND_ORDER_SMS')) {
+            event(new NewOrderEvent($order));
+        }
 
         return $order->fresh();
     }
@@ -76,6 +78,5 @@ class NewOrderRepository extends Repository
         } catch (Exception $e) {
             throw new AException($e->getMessage(), $e->getCode());
         }
-
     }
 }

--- a/app/Repositories/PaymentReconcileRepository.php
+++ b/app/Repositories/PaymentReconcileRepository.php
@@ -35,9 +35,7 @@ class PaymentReconcileRepository extends Repository
         $payment_type = PaymentType::where('id', $data["payment_type_id"])->first();
 
         if ($payment_type->type == PaymentType::REPAYMENTS) {
-            if (env('SEND_REORDER_SMS')) {
-                event(new RepaymentEvent($model));
-            }
+            event(new RepaymentEvent($model));
         }
         return $resp;
     }


### PR DESCRIPTION
#### What does this PR do?
- Changes the verbiage sent to customers upon placing a new order and repayment.

#### Description of Task proposed in this pull request?
- Changed the verbiage sent to customers for successful order and repayment. 

#### How should this be manually tested (Quality Assurance)?
- Make a new order and try to make a repayment for an existing order 

#### Any background context you want to add (Operations Impact)?
- Add "SEND_ORDER_SMS" and "SEND_REORDER_SMS" to environment variables, they both accept boolean value