### PR TITLE
fix duplicate documents

### DIFF
--- a/app/Http/Controllers/NewDocumentController.php
+++ b/app/Http/Controllers/NewDocumentController.php
@@ -70,8 +70,17 @@ class NewDocumentController extends Controller
 
 
             $customer = Customer::find($request['customer_id']);
+            $data = [
+                "document_type" => $document->document_type,
+                "name" => $document->name,
+                "user_id" => $document->user_id,
+                "document_url" => $document->document_url
+            ];
 
-            $customer->newDocuments()->save($document);
+            $customer->newDocuments()->updateOrCreate(['name' => $request['name']], $data);
+
+
+
         }
 
         /** if the check 3 is not passed it return the record for the document with no changes

--- a/app/Models/NewDocument.php
+++ b/app/Models/NewDocument.php
@@ -10,6 +10,8 @@ class NewDocument extends Model
     //
     use SoftDeletes;
 
+    protected $guarded = [];
+
     public function documentable(){
         return $this->morphTo();
     }


### PR DESCRIPTION
We need unique named documents to fix duplicate cards on the front end. So if a document exist for a customer and the url is updated, it will not be duplicated